### PR TITLE
[MUI] 発送管理画面実装 (issue-401, 402, 403)

### DIFF
--- a/apps/admin-mui/src/menu-items/index.jsx
+++ b/apps/admin-mui/src/menu-items/index.jsx
@@ -3,11 +3,12 @@ import dashboard from './dashboard';
 import pages from './page';
 import utilities from './utilities';
 import support from './support';
+import shipping from './shipping';
 
 // ==============================|| MENU ITEMS ||============================== //
 
 const menuItems = {
-  items: [dashboard, pages, utilities, support]
+  items: [dashboard, shipping, pages, utilities, support]
 };
 
 export default menuItems;

--- a/apps/admin-mui/src/menu-items/shipping.tsx
+++ b/apps/admin-mui/src/menu-items/shipping.tsx
@@ -1,0 +1,37 @@
+// assets
+import { SendOutlined, UnorderedListOutlined, DashboardOutlined } from '@ant-design/icons';
+
+// icons
+const icons = {
+  SendOutlined,
+  UnorderedListOutlined,
+  DashboardOutlined
+};
+
+// ==============================|| MENU ITEMS - SHIPPING ||============================== //
+
+const shipping = {
+  id: 'group-shipping',
+  title: '発送管理',
+  type: 'group',
+  children: [
+    {
+      id: 'shipping-summary',
+      title: '発送管理サマリー',
+      type: 'item',
+      url: '/shipping/summary',
+      icon: icons.DashboardOutlined,
+      breadcrumbs: false
+    },
+    {
+      id: 'shipping-list',
+      title: '発送一覧',
+      type: 'item',
+      url: '/shipping/list',
+      icon: icons.UnorderedListOutlined,
+      breadcrumbs: false
+    }
+  ]
+};
+
+export default shipping;

--- a/apps/admin-mui/src/pages/shipping/components/ShippingDetailDrawer.tsx
+++ b/apps/admin-mui/src/pages/shipping/components/ShippingDetailDrawer.tsx
@@ -1,0 +1,569 @@
+import { useState, useEffect, useCallback } from 'react';
+
+// material-ui
+import Drawer from '@mui/material/Drawer';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Skeleton from '@mui/material/Skeleton';
+import Alert from '@mui/material/Alert';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import TextField from '@mui/material/TextField';
+import Stepper from '@mui/material/Stepper';
+import Step from '@mui/material/Step';
+import StepLabel from '@mui/material/StepLabel';
+import Link from '@mui/material/Link';
+import Tooltip from '@mui/material/Tooltip';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogActions from '@mui/material/DialogActions';
+import Snackbar from '@mui/material/Snackbar';
+
+// assets
+import {
+  CloseOutlined,
+  CopyOutlined,
+  ExportOutlined,
+  WarningOutlined,
+  ReloadOutlined
+} from '@ant-design/icons';
+
+// services
+import {
+  getShipping,
+  updateShipping,
+  STATUS_COLORS,
+  STATUS_LABELS,
+  CARRIER_NAMES,
+  CARRIER_TRACKING_URLS,
+  Shipping,
+  UpdateParams
+} from 'services/shipping';
+
+// ==============================|| SHIPPING DETAIL DRAWER ||============================== //
+
+interface ShippingDetailDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  orderId: string | null;
+  onUpdate?: () => void;
+}
+
+const STATUS_STEPS = ['CREATED', 'READY', 'SHIPPED', 'DELIVERED'];
+const STATUS_STEP_LABELS = ['作成', '出荷準備中', '出荷済み', '配達完了'];
+
+function getNextStatuses(currentStatus: string): { value: string; label: string }[] {
+  switch (currentStatus) {
+    case 'CREATED':
+      return [{ value: 'READY', label: '出荷準備中' }];
+    case 'READY':
+      return [{ value: 'SHIPPED', label: '出荷済み' }];
+    case 'SHIPPED':
+      return [{ value: 'DELIVERED', label: '配達完了' }];
+    default:
+      return [];
+  }
+}
+
+function formatDateTime(value?: string | null): string {
+  if (!value) return '-';
+  try {
+    const date = new Date(value);
+    if (isNaN(date.getTime()) || date.getFullYear() <= 1) return '-';
+    return date.toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit'
+    });
+  } catch {
+    return '-';
+  }
+}
+
+export default function ShippingDetailDrawer({
+  open,
+  onClose,
+  orderId,
+  onUpdate
+}: ShippingDetailDrawerProps) {
+  // State
+  const [shipping, setShipping] = useState<Shipping | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [updating, setUpdating] = useState(false);
+  const [conflictError, setConflictError] = useState(false);
+
+  // Form state
+  const [newStatus, setNewStatus] = useState('');
+  const [newCarrier, setNewCarrier] = useState('');
+  const [newTrackingNumber, setNewTrackingNumber] = useState('');
+
+  // Return dialog
+  const [returnDialogOpen, setReturnDialogOpen] = useState(false);
+
+  // Snackbar
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({
+    open: false,
+    message: '',
+    severity: 'success'
+  });
+
+  const fetchShipping = useCallback(async () => {
+    if (!orderId) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await getShipping(orderId);
+      if (response.success && response.data) {
+        setShipping(response.data);
+        setNewCarrier(response.data.carrier || '');
+        setNewTrackingNumber(response.data.tracking_number || '');
+        setNewStatus('');
+        setConflictError(false);
+      } else {
+        setError(response.errorMessage || 'データの取得に失敗しました');
+      }
+    } catch (err) {
+      setError('データの取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }, [orderId]);
+
+  useEffect(() => {
+    if (open && orderId) {
+      fetchShipping();
+    }
+  }, [open, orderId, fetchShipping]);
+
+  const handleClose = () => {
+    setShipping(null);
+    setError(null);
+    setConflictError(false);
+    setNewStatus('');
+    setNewCarrier('');
+    setNewTrackingNumber('');
+    onClose();
+  };
+
+  const getCurrentStep = (): number => {
+    if (!shipping) return -1;
+    if (shipping.status === 'RETURNED' || shipping.status === 'CANCELLED') {
+      return -1;
+    }
+    return STATUS_STEPS.indexOf(shipping.status);
+  };
+
+  const handleOpenTracking = () => {
+    if (shipping?.carrier && shipping?.tracking_number) {
+      const url = CARRIER_TRACKING_URLS[shipping.carrier] + shipping.tracking_number;
+      window.open(url, '_blank');
+    }
+  };
+
+  const handleCopyTrackingNumber = async () => {
+    if (shipping?.tracking_number) {
+      try {
+        await navigator.clipboard.writeText(shipping.tracking_number);
+        setSnackbar({ open: true, message: 'コピーしました', severity: 'success' });
+      } catch {
+        setSnackbar({ open: true, message: 'コピーに失敗しました', severity: 'error' });
+      }
+    }
+  };
+
+  const handleStatusUpdate = async () => {
+    if (!shipping || !newStatus) {
+      setSnackbar({ open: true, message: '変更後のステータスを選択してください', severity: 'error' });
+      return;
+    }
+
+    // Validation for SHIPPED status
+    if (newStatus === 'SHIPPED') {
+      if (!newCarrier) {
+        setSnackbar({ open: true, message: '出荷済みにするには配送業者を選択してください', severity: 'error' });
+        return;
+      }
+      if (!newTrackingNumber) {
+        setSnackbar({ open: true, message: '出荷済みにするには追跡番号を入力してください', severity: 'error' });
+        return;
+      }
+    }
+
+    setUpdating(true);
+    setConflictError(false);
+
+    try {
+      const updateData: UpdateParams = {
+        status: newStatus,
+        version: shipping.version
+      };
+
+      if (newStatus === 'SHIPPED') {
+        updateData.carrier = newCarrier;
+        updateData.tracking_number = newTrackingNumber;
+      }
+
+      const response = await updateShipping(shipping.order_id, updateData);
+
+      if (response.success) {
+        setSnackbar({ open: true, message: 'ステータスを更新しました', severity: 'success' });
+        fetchShipping();
+        onUpdate?.();
+        setNewStatus('');
+      } else {
+        if (response.errorCode === 409) {
+          setConflictError(true);
+          setSnackbar({ open: true, message: 'データが更新されています。再読み込みしてください。', severity: 'error' });
+        } else {
+          setSnackbar({ open: true, message: response.errorMessage || '更新に失敗しました', severity: 'error' });
+        }
+      }
+    } catch (err) {
+      setSnackbar({ open: true, message: '更新に失敗しました', severity: 'error' });
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  const handleReturn = async () => {
+    if (!shipping) return;
+
+    setUpdating(true);
+    setConflictError(false);
+    setReturnDialogOpen(false);
+
+    try {
+      const response = await updateShipping(shipping.order_id, {
+        status: 'RETURNED',
+        version: shipping.version
+      });
+
+      if (response.success) {
+        setSnackbar({ open: true, message: '返送処理を実行しました', severity: 'success' });
+        fetchShipping();
+        onUpdate?.();
+      } else {
+        if (response.errorCode === 409) {
+          setConflictError(true);
+          setSnackbar({ open: true, message: 'データが更新されています。再読み込みしてください。', severity: 'error' });
+        } else {
+          setSnackbar({ open: true, message: response.errorMessage || '返送処理に失敗しました', severity: 'error' });
+        }
+      }
+    } catch (err) {
+      setSnackbar({ open: true, message: '返送処理に失敗しました', severity: 'error' });
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  const handleRefresh = () => {
+    setConflictError(false);
+    fetchShipping();
+  };
+
+  const nextStatuses = shipping ? getNextStatuses(shipping.status) : [];
+  const canUpdate = nextStatuses.length > 0;
+  const canReturn = shipping && !['RETURNED', 'CANCELLED', 'DELIVERED'].includes(shipping.status);
+
+  return (
+    <>
+      <Drawer
+        anchor="right"
+        open={open}
+        onClose={handleClose}
+        PaperProps={{ sx: { width: { xs: '100%', sm: 480 } } }}
+      >
+        {/* Header */}
+        <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}>
+          <Stack direction="row" justifyContent="space-between" alignItems="center">
+            <Typography variant="h5">
+              発送詳細{orderId ? `: ${orderId}` : ''}
+            </Typography>
+            <Stack direction="row" spacing={1}>
+              {shipping && (
+                <Chip
+                  label={STATUS_LABELS[shipping.status] || shipping.status}
+                  color={STATUS_COLORS[shipping.status] || 'default'}
+                  size="small"
+                />
+              )}
+              <IconButton size="small" onClick={handleClose}>
+                <CloseOutlined />
+              </IconButton>
+            </Stack>
+          </Stack>
+        </Box>
+
+        {/* Content */}
+        <Box sx={{ p: 2, overflow: 'auto', flex: 1 }}>
+          {loading ? (
+            <Stack spacing={2}>
+              <Skeleton variant="rectangular" height={100} />
+              <Skeleton variant="rectangular" height={150} />
+              <Skeleton variant="rectangular" height={100} />
+            </Stack>
+          ) : error ? (
+            <Alert severity="error">{error}</Alert>
+          ) : !shipping ? (
+            <Box sx={{ textAlign: 'center', py: 4 }}>
+              <Typography color="text.secondary">データが見つかりません</Typography>
+            </Box>
+          ) : (
+            <Stack spacing={3}>
+              {/* Conflict Error Alert */}
+              {conflictError && (
+                <Alert
+                  severity="error"
+                  icon={<WarningOutlined />}
+                  action={
+                    <Button color="inherit" size="small" onClick={handleRefresh} startIcon={<ReloadOutlined />}>
+                      再読み込み
+                    </Button>
+                  }
+                >
+                  他のユーザーによりデータが更新されました。
+                </Alert>
+              )}
+
+              {/* Basic Info */}
+              <Box>
+                <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                  基本情報
+                </Typography>
+                <Stack spacing={1.5}>
+                  <Stack direction="row" justifyContent="space-between">
+                    <Typography variant="body2" color="text.secondary">注文ID</Typography>
+                    <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>{shipping.order_id}</Typography>
+                  </Stack>
+                  <Stack direction="row" justifyContent="space-between">
+                    <Typography variant="body2" color="text.secondary">ステータス</Typography>
+                    <Chip
+                      label={STATUS_LABELS[shipping.status] || shipping.status}
+                      color={STATUS_COLORS[shipping.status] || 'default'}
+                      size="small"
+                    />
+                  </Stack>
+                  <Stack direction="row" justifyContent="space-between">
+                    <Typography variant="body2" color="text.secondary">配送先住所</Typography>
+                    <Typography variant="body2" sx={{ maxWidth: 200, textAlign: 'right' }}>
+                      {shipping.shipping_address || '-'}
+                    </Typography>
+                  </Stack>
+                  <Stack direction="row" justifyContent="space-between">
+                    <Typography variant="body2" color="text.secondary">配送業者</Typography>
+                    <Typography variant="body2">
+                      {shipping.carrier ? CARRIER_NAMES[shipping.carrier] || shipping.carrier : '-'}
+                    </Typography>
+                  </Stack>
+                  <Stack direction="row" justifyContent="space-between" alignItems="center">
+                    <Typography variant="body2" color="text.secondary">追跡番号</Typography>
+                    {shipping.tracking_number ? (
+                      <Stack direction="row" alignItems="center" spacing={0.5}>
+                        <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                          {shipping.tracking_number}
+                        </Typography>
+                        <Tooltip title="コピー">
+                          <IconButton size="small" onClick={handleCopyTrackingNumber}>
+                            <CopyOutlined style={{ fontSize: 14 }} />
+                          </IconButton>
+                        </Tooltip>
+                        {shipping.carrier && (
+                          <Tooltip title="追跡サイトを開く">
+                            <IconButton size="small" onClick={handleOpenTracking}>
+                              <ExportOutlined style={{ fontSize: 14 }} />
+                            </IconButton>
+                          </Tooltip>
+                        )}
+                      </Stack>
+                    ) : (
+                      <Typography variant="body2">-</Typography>
+                    )}
+                  </Stack>
+                  <Stack direction="row" justifyContent="space-between">
+                    <Typography variant="body2" color="text.secondary">作成日時</Typography>
+                    <Typography variant="body2">{formatDateTime(shipping.created_at)}</Typography>
+                  </Stack>
+                  <Stack direction="row" justifyContent="space-between">
+                    <Typography variant="body2" color="text.secondary">更新日時</Typography>
+                    <Typography variant="body2">{formatDateTime(shipping.updated_at)}</Typography>
+                  </Stack>
+                </Stack>
+              </Box>
+
+              <Divider />
+
+              {/* Status History */}
+              <Box>
+                <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                  ステータス履歴
+                </Typography>
+                {shipping.status !== 'RETURNED' && shipping.status !== 'CANCELLED' ? (
+                  <Stepper activeStep={getCurrentStep()} orientation="vertical">
+                    {STATUS_STEP_LABELS.map((label, index) => (
+                      <Step key={label}>
+                        <StepLabel>
+                          <Typography variant="body2">{label}</Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {index === 0 && formatDateTime(shipping.created_at)}
+                            {index === 1 && formatDateTime(shipping.ready_at)}
+                            {index === 2 && formatDateTime(shipping.shipped_at)}
+                            {index === 3 && formatDateTime(shipping.delivered_at)}
+                          </Typography>
+                        </StepLabel>
+                      </Step>
+                    ))}
+                  </Stepper>
+                ) : (
+                  <Stepper activeStep={1} orientation="vertical">
+                    <Step>
+                      <StepLabel>
+                        <Typography variant="body2">作成</Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {formatDateTime(shipping.created_at)}
+                        </Typography>
+                      </StepLabel>
+                    </Step>
+                    <Step>
+                      <StepLabel error>
+                        <Typography variant="body2">
+                          {shipping.status === 'RETURNED' ? '返送' : 'キャンセル'}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {formatDateTime(shipping.updated_at)}
+                        </Typography>
+                      </StepLabel>
+                    </Step>
+                  </Stepper>
+                )}
+              </Box>
+
+              {/* Status Update Form */}
+              {canUpdate && (
+                <>
+                  <Divider />
+                  <Box>
+                    <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                      ステータス更新
+                    </Typography>
+                    <Stack spacing={2}>
+                      <FormControl fullWidth size="small">
+                        <InputLabel>変更後のステータス</InputLabel>
+                        <Select
+                          value={newStatus}
+                          label="変更後のステータス"
+                          onChange={(e: SelectChangeEvent) => setNewStatus(e.target.value)}
+                        >
+                          <MenuItem value="">選択してください</MenuItem>
+                          {nextStatuses.map((s) => (
+                            <MenuItem key={s.value} value={s.value}>
+                              {s.label}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+
+                      {newStatus === 'SHIPPED' && (
+                        <>
+                          <FormControl fullWidth size="small" required>
+                            <InputLabel>配送業者</InputLabel>
+                            <Select
+                              value={newCarrier}
+                              label="配送業者"
+                              onChange={(e: SelectChangeEvent) => setNewCarrier(e.target.value)}
+                            >
+                              <MenuItem value="">選択してください</MenuItem>
+                              <MenuItem value="YAMATO">ヤマト運輸</MenuItem>
+                              <MenuItem value="SAGAWA">佐川急便</MenuItem>
+                              <MenuItem value="JAPANPOST">日本郵便</MenuItem>
+                            </Select>
+                          </FormControl>
+                          <TextField
+                            fullWidth
+                            size="small"
+                            label="追跡番号"
+                            value={newTrackingNumber}
+                            onChange={(e) => setNewTrackingNumber(e.target.value)}
+                            required
+                          />
+                        </>
+                      )}
+
+                      <Button
+                        variant="contained"
+                        fullWidth
+                        onClick={handleStatusUpdate}
+                        disabled={updating || conflictError || !newStatus}
+                      >
+                        ステータス更新
+                      </Button>
+                    </Stack>
+                  </Box>
+                </>
+              )}
+
+              {/* Return Button */}
+              {canReturn && (
+                <>
+                  <Divider />
+                  <Button
+                    variant="outlined"
+                    color="error"
+                    fullWidth
+                    onClick={() => setReturnDialogOpen(true)}
+                    disabled={updating || conflictError}
+                  >
+                    返送処理
+                  </Button>
+                </>
+              )}
+            </Stack>
+          )}
+        </Box>
+      </Drawer>
+
+      {/* Return Confirmation Dialog */}
+      <Dialog open={returnDialogOpen} onClose={() => setReturnDialogOpen(false)}>
+        <DialogTitle>返送処理</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            この発送を返送処理しますか？この操作は元に戻せません。
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setReturnDialogOpen(false)}>キャンセル</Button>
+          <Button onClick={handleReturn} color="error" variant="contained">
+            返送する
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Snackbar */}
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={3000}
+        onClose={() => setSnackbar({ ...snackbar, open: false })}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={snackbar.severity} onClose={() => setSnackbar({ ...snackbar, open: false })}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}

--- a/apps/admin-mui/src/pages/shipping/list.tsx
+++ b/apps/admin-mui/src/pages/shipping/list.tsx
@@ -1,0 +1,380 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+// material-ui
+import Grid from '@mui/material/Grid';
+import Typography from '@mui/material/Typography';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import TablePagination from '@mui/material/TablePagination';
+import Chip from '@mui/material/Chip';
+import TextField from '@mui/material/TextField';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+
+// project imports
+import MainCard from 'components/MainCard';
+
+// assets
+import { CopyOutlined, ReloadOutlined, EditOutlined } from '@ant-design/icons';
+
+// services
+import {
+  getShippings,
+  STATUS_COLORS,
+  STATUS_LABELS,
+  CARRIER_NAMES,
+  Shipping,
+  ListParams
+} from 'services/shipping';
+
+// components
+import ShippingDetailDrawer from './components/ShippingDetailDrawer';
+
+// ==============================|| SHIPPING LIST ||============================== //
+
+function formatDateTime(value?: string | null): string {
+  if (!value) return '-';
+  try {
+    const date = new Date(value);
+    if (isNaN(date.getTime()) || date.getFullYear() <= 1) return '-';
+    return date.toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  } catch {
+    return '-';
+  }
+}
+
+export default function ShippingList() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // State
+  const [shippings, setShippings] = useState<Shipping[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(20);
+
+  // Filters
+  const [status, setStatus] = useState(searchParams.get('status') || '');
+  const [carrier, setCarrier] = useState('');
+  const [keyword, setKeyword] = useState('');
+
+  // Drawer
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
+
+  // Snackbar
+  const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({
+    open: false,
+    message: '',
+    severity: 'success'
+  });
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params: ListParams = {
+        page: page + 1,
+        size: rowsPerPage
+      };
+      if (status) params.status = status;
+      if (carrier) params.carrier = carrier;
+      if (keyword) params.keyword = keyword;
+
+      const response = await getShippings(params);
+
+      if (response.success) {
+        setShippings(response.data || []);
+        setTotal(response.total || 0);
+      }
+    } catch (error) {
+      console.error('Failed to fetch shippings:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, rowsPerPage, status, carrier, keyword]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Handle URL params for orderId
+  useEffect(() => {
+    const orderId = searchParams.get('orderId');
+    if (orderId) {
+      setSelectedOrderId(orderId);
+      setDrawerOpen(true);
+      // Clear the orderId param
+      searchParams.delete('orderId');
+      setSearchParams(searchParams);
+    }
+  }, [searchParams, setSearchParams]);
+
+  const handleRowClick = (shipping: Shipping) => {
+    setSelectedOrderId(shipping.order_id);
+    setDrawerOpen(true);
+  };
+
+  const handleDrawerClose = () => {
+    setDrawerOpen(false);
+    setSelectedOrderId(null);
+  };
+
+  const handleDrawerUpdate = () => {
+    fetchData();
+  };
+
+  const handleChangePage = (_event: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  const handleStatusChange = (event: SelectChangeEvent) => {
+    setStatus(event.target.value);
+    setPage(0);
+  };
+
+  const handleCarrierChange = (event: SelectChangeEvent) => {
+    setCarrier(event.target.value);
+    setPage(0);
+  };
+
+  const handleKeywordChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setKeyword(event.target.value);
+  };
+
+  const handleKeywordKeyPress = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      setPage(0);
+      fetchData();
+    }
+  };
+
+  const handleResetFilters = () => {
+    setStatus('');
+    setCarrier('');
+    setKeyword('');
+    setPage(0);
+  };
+
+  const handleCopyTrackingNumber = async (trackingNumber: string, event: React.MouseEvent) => {
+    event.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(trackingNumber);
+      setSnackbar({ open: true, message: 'コピーしました', severity: 'success' });
+    } catch {
+      setSnackbar({ open: true, message: 'コピーに失敗しました', severity: 'error' });
+    }
+  };
+
+  const handleRefresh = () => {
+    fetchData();
+  };
+
+  return (
+    <Grid container rowSpacing={4.5} columnSpacing={2.75}>
+      {/* Header */}
+      <Grid sx={{ mb: -2.25 }} size={12}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Typography variant="h5">発送一覧</Typography>
+          <IconButton onClick={handleRefresh} size="small">
+            <ReloadOutlined />
+          </IconButton>
+        </Stack>
+      </Grid>
+
+      {/* Filters */}
+      <Grid size={12}>
+        <MainCard>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="center">
+            <TextField
+              size="small"
+              label="キーワード"
+              placeholder="注文ID・追跡番号"
+              value={keyword}
+              onChange={handleKeywordChange}
+              onKeyPress={handleKeywordKeyPress}
+              sx={{ minWidth: 200 }}
+            />
+            <FormControl size="small" sx={{ minWidth: 150 }}>
+              <InputLabel>ステータス</InputLabel>
+              <Select value={status} label="ステータス" onChange={handleStatusChange}>
+                <MenuItem value="">すべて</MenuItem>
+                <MenuItem value="CREATED">未着手</MenuItem>
+                <MenuItem value="READY">出荷準備中</MenuItem>
+                <MenuItem value="SHIPPED">出荷済み</MenuItem>
+                <MenuItem value="DELIVERED">配達完了</MenuItem>
+                <MenuItem value="RETURNED">返送</MenuItem>
+                <MenuItem value="CANCELLED">キャンセル</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControl size="small" sx={{ minWidth: 150 }}>
+              <InputLabel>配送業者</InputLabel>
+              <Select value={carrier} label="配送業者" onChange={handleCarrierChange}>
+                <MenuItem value="">すべて</MenuItem>
+                <MenuItem value="YAMATO">ヤマト運輸</MenuItem>
+                <MenuItem value="SAGAWA">佐川急便</MenuItem>
+                <MenuItem value="JAPANPOST">日本郵便</MenuItem>
+              </Select>
+            </FormControl>
+            <Button variant="outlined" size="small" onClick={handleResetFilters}>
+              リセット
+            </Button>
+          </Stack>
+        </MainCard>
+      </Grid>
+
+      {/* Table */}
+      <Grid size={12}>
+        <MainCard content={false}>
+          <TableContainer>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>注文ID</TableCell>
+                  <TableCell>ステータス</TableCell>
+                  <TableCell>配送業者</TableCell>
+                  <TableCell>追跡番号</TableCell>
+                  <TableCell>更新日時</TableCell>
+                  <TableCell align="center">操作</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {loading ? (
+                  [...Array(5)].map((_, index) => (
+                    <TableRow key={index}>
+                      <TableCell><Skeleton /></TableCell>
+                      <TableCell><Skeleton /></TableCell>
+                      <TableCell><Skeleton /></TableCell>
+                      <TableCell><Skeleton /></TableCell>
+                      <TableCell><Skeleton /></TableCell>
+                      <TableCell><Skeleton /></TableCell>
+                    </TableRow>
+                  ))
+                ) : shippings.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                      <Typography color="text.secondary">データがありません</Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  shippings.map((shipping) => (
+                    <TableRow
+                      key={shipping.id}
+                      hover
+                      sx={{ cursor: 'pointer' }}
+                      onClick={() => handleRowClick(shipping)}
+                    >
+                      <TableCell>
+                        <Typography
+                          sx={{ fontFamily: 'monospace', color: 'primary.main' }}
+                        >
+                          {shipping.order_id}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Chip
+                          label={STATUS_LABELS[shipping.status] || shipping.status}
+                          color={STATUS_COLORS[shipping.status] || 'default'}
+                          size="small"
+                        />
+                      </TableCell>
+                      <TableCell>
+                        {shipping.carrier ? CARRIER_NAMES[shipping.carrier] || shipping.carrier : '-'}
+                      </TableCell>
+                      <TableCell>
+                        {shipping.tracking_number ? (
+                          <Stack direction="row" alignItems="center" spacing={0.5}>
+                            <Typography sx={{ fontFamily: 'monospace' }}>
+                              {shipping.tracking_number}
+                            </Typography>
+                            <Tooltip title="コピー">
+                              <IconButton
+                                size="small"
+                                onClick={(e) => handleCopyTrackingNumber(shipping.tracking_number!, e)}
+                              >
+                                <CopyOutlined style={{ fontSize: 14 }} />
+                              </IconButton>
+                            </Tooltip>
+                          </Stack>
+                        ) : (
+                          '-'
+                        )}
+                      </TableCell>
+                      <TableCell>{formatDateTime(shipping.updated_at)}</TableCell>
+                      <TableCell align="center">
+                        <IconButton
+                          size="small"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleRowClick(shipping);
+                          }}
+                        >
+                          <EditOutlined />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          <TablePagination
+            component="div"
+            count={total}
+            page={page}
+            onPageChange={handleChangePage}
+            rowsPerPage={rowsPerPage}
+            onRowsPerPageChange={handleChangeRowsPerPage}
+            rowsPerPageOptions={[10, 20, 50]}
+            labelRowsPerPage="表示件数"
+          />
+        </MainCard>
+      </Grid>
+
+      {/* Detail Drawer */}
+      <ShippingDetailDrawer
+        open={drawerOpen}
+        onClose={handleDrawerClose}
+        orderId={selectedOrderId}
+        onUpdate={handleDrawerUpdate}
+      />
+
+      {/* Snackbar */}
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={3000}
+        onClose={() => setSnackbar({ ...snackbar, open: false })}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={snackbar.severity} onClose={() => setSnackbar({ ...snackbar, open: false })}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Grid>
+  );
+}

--- a/apps/admin-mui/src/pages/shipping/summary.tsx
+++ b/apps/admin-mui/src/pages/shipping/summary.tsx
@@ -1,0 +1,274 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+// material-ui
+import Grid from '@mui/material/Grid';
+import Typography from '@mui/material/Typography';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Chip from '@mui/material/Chip';
+import Skeleton from '@mui/material/Skeleton';
+import Box from '@mui/material/Box';
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+
+// project imports
+import MainCard from 'components/MainCard';
+
+// assets
+import {
+  InboxOutlined,
+  CheckCircleOutlined,
+  SendOutlined,
+  ExclamationCircleOutlined
+} from '@ant-design/icons';
+
+// services
+import {
+  getSummary,
+  getPriorityShippings,
+  STATUS_COLORS,
+  STATUS_LABELS,
+  Summary,
+  Shipping
+} from 'services/shipping';
+
+// ==============================|| SHIPPING SUMMARY ||============================== //
+
+interface SummaryCardProps {
+  title: string;
+  count: number;
+  icon: React.ReactNode;
+  color: string;
+  loading: boolean;
+  onClick: () => void;
+}
+
+function SummaryCard({ title, count, icon, color, loading, onClick }: SummaryCardProps) {
+  return (
+    <MainCard
+      contentSX={{ p: 2.25, cursor: 'pointer', '&:hover': { bgcolor: 'action.hover' } }}
+      onClick={onClick}
+    >
+      <Stack sx={{ gap: 0.5 }}>
+        <Typography variant="h6" color="text.secondary">
+          {title}
+        </Typography>
+        <Grid container sx={{ alignItems: 'center' }}>
+          <Grid>
+            {loading ? (
+              <Skeleton width={60} height={40} />
+            ) : (
+              <Typography variant="h4" color="inherit">
+                {count}
+              </Typography>
+            )}
+          </Grid>
+          <Grid sx={{ ml: 'auto' }}>
+            <Box sx={{ color, fontSize: '2rem' }}>{icon}</Box>
+          </Grid>
+        </Grid>
+      </Stack>
+    </MainCard>
+  );
+}
+
+function formatDateTime(value?: string | null): string {
+  if (!value) return '-';
+  try {
+    const date = new Date(value);
+    if (isNaN(date.getTime()) || date.getFullYear() <= 1) return '-';
+    return date.toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  } catch {
+    return '-';
+  }
+}
+
+function getPriorityReason(shipping: Shipping): string {
+  if (shipping.status === 'RETURNED') {
+    return '返送対応が必要';
+  }
+  if (shipping.status === 'CREATED') {
+    const createdAt = new Date(shipping.created_at);
+    const hoursAgo = Math.floor((Date.now() - createdAt.getTime()) / (1000 * 60 * 60));
+    if (hoursAgo >= 24) {
+      return `${hoursAgo}時間以上未処理`;
+    }
+    return '未処理';
+  }
+  if (shipping.status === 'READY') {
+    return '出荷作業待ち';
+  }
+  return '';
+}
+
+export default function ShippingSummary() {
+  const navigate = useNavigate();
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [priorityShippings, setPriorityShippings] = useState<Shipping[]>([]);
+  const [summaryLoading, setSummaryLoading] = useState(true);
+  const [priorityLoading, setPriorityLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [summaryRes, priorityRes] = await Promise.all([
+          getSummary(),
+          getPriorityShippings(5)
+        ]);
+
+        if (summaryRes.success && summaryRes.data) {
+          setSummary(summaryRes.data);
+        }
+        if (priorityRes.success && priorityRes.data) {
+          setPriorityShippings(priorityRes.data);
+        }
+      } catch (error) {
+        console.error('Failed to fetch data:', error);
+      } finally {
+        setSummaryLoading(false);
+        setPriorityLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const handleCardClick = (status: string) => {
+    navigate(`/shipping/list?status=${status}`);
+  };
+
+  return (
+    <Grid container rowSpacing={4.5} columnSpacing={2.75}>
+      {/* Header */}
+      <Grid sx={{ mb: -2.25 }} size={12}>
+        <Typography variant="h5">発送管理サマリー</Typography>
+      </Grid>
+
+      {/* Summary Cards */}
+      <Grid size={{ xs: 12, sm: 6, lg: 3 }}>
+        <SummaryCard
+          title="未着手"
+          count={summary?.created ?? 0}
+          icon={<InboxOutlined />}
+          color="#8c8c8c"
+          loading={summaryLoading}
+          onClick={() => handleCardClick('CREATED')}
+        />
+      </Grid>
+      <Grid size={{ xs: 12, sm: 6, lg: 3 }}>
+        <SummaryCard
+          title="出荷作業待ち"
+          count={summary?.ready ?? 0}
+          icon={<CheckCircleOutlined />}
+          color="#1890ff"
+          loading={summaryLoading}
+          onClick={() => handleCardClick('READY')}
+        />
+      </Grid>
+      <Grid size={{ xs: 12, sm: 6, lg: 3 }}>
+        <SummaryCard
+          title="本日出荷"
+          count={summary?.shipped_today ?? 0}
+          icon={<SendOutlined />}
+          color="#52c41a"
+          loading={summaryLoading}
+          onClick={() => handleCardClick('SHIPPED')}
+        />
+      </Grid>
+      <Grid size={{ xs: 12, sm: 6, lg: 3 }}>
+        <SummaryCard
+          title="返送/トラブル"
+          count={summary?.returned ?? 0}
+          icon={<ExclamationCircleOutlined />}
+          color="#ff4d4f"
+          loading={summaryLoading}
+          onClick={() => handleCardClick('RETURNED')}
+        />
+      </Grid>
+
+      {/* Priority Shippings Table */}
+      <Grid size={12}>
+        <MainCard
+          title={
+            <Typography variant="h5">要対応発送リスト</Typography>
+          }
+          secondary={
+            <Link
+              component="button"
+              variant="body2"
+              onClick={() => navigate('/shipping/list')}
+              sx={{ cursor: 'pointer' }}
+            >
+              すべて表示
+            </Link>
+          }
+        >
+          {priorityLoading ? (
+            <Box sx={{ p: 2 }}>
+              <Skeleton height={40} />
+              <Skeleton height={40} />
+              <Skeleton height={40} />
+            </Box>
+          ) : priorityShippings.length === 0 ? (
+            <Box sx={{ p: 4, textAlign: 'center' }}>
+              <Typography color="text.secondary">
+                対応が必要な発送はありません
+              </Typography>
+            </Box>
+          ) : (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>注文ID</TableCell>
+                    <TableCell>ステータス</TableCell>
+                    <TableCell>理由</TableCell>
+                    <TableCell>更新日時</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {priorityShippings.map((shipping) => (
+                    <TableRow
+                      key={shipping.id}
+                      hover
+                      sx={{ cursor: 'pointer' }}
+                      onClick={() => navigate(`/shipping/list?orderId=${shipping.order_id}`)}
+                    >
+                      <TableCell>
+                        <Link component="button" variant="body2">
+                          {shipping.order_id}
+                        </Link>
+                      </TableCell>
+                      <TableCell>
+                        <Chip
+                          label={STATUS_LABELS[shipping.status] || shipping.status}
+                          color={STATUS_COLORS[shipping.status] || 'default'}
+                          size="small"
+                        />
+                      </TableCell>
+                      <TableCell>{getPriorityReason(shipping)}</TableCell>
+                      <TableCell>{formatDateTime(shipping.updated_at)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </MainCard>
+      </Grid>
+    </Grid>
+  );
+}

--- a/apps/admin-mui/src/routes/MainRoutes.jsx
+++ b/apps/admin-mui/src/routes/MainRoutes.jsx
@@ -15,6 +15,10 @@ const Shadow = Loadable(lazy(() => import('pages/component-overview/shadows')));
 // render - sample page
 const SamplePage = Loadable(lazy(() => import('pages/extra-pages/sample-page')));
 
+// render - shipping
+const ShippingSummary = Loadable(lazy(() => import('pages/shipping/summary')));
+const ShippingList = Loadable(lazy(() => import('pages/shipping/list')));
+
 // ==============================|| MAIN ROUTING ||============================== //
 
 const MainRoutes = {
@@ -31,6 +35,19 @@ const MainRoutes = {
         {
           path: 'default',
           element: <DashboardDefault />
+        }
+      ]
+    },
+    {
+      path: 'shipping',
+      children: [
+        {
+          path: 'summary',
+          element: <ShippingSummary />
+        },
+        {
+          path: 'list',
+          element: <ShippingList />
         }
       ]
     },

--- a/apps/admin-mui/src/services/shipping.ts
+++ b/apps/admin-mui/src/services/shipping.ts
@@ -1,0 +1,471 @@
+// Types
+export interface Summary {
+  created: number;
+  ready: number;
+  shipped_today: number;
+  returned: number;
+}
+
+export interface Shipping {
+  id: number;
+  order_id: string;
+  status: string;
+  carrier: string | null;
+  tracking_number: string | null;
+  shipping_address: string;
+  ready_at: string | null;
+  shipped_at: string | null;
+  delivered_at: string | null;
+  version: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ApiResponse<T> {
+  success: boolean;
+  data: T;
+  errorCode?: number;
+  errorMessage?: string;
+}
+
+export interface ListResponse {
+  success: boolean;
+  data: Shipping[];
+  total: number;
+  page: number;
+  size: number;
+}
+
+export interface ListParams {
+  status?: string;
+  carrier?: string;
+  keyword?: string;
+  page?: number;
+  size?: number;
+}
+
+export interface UpdateParams {
+  status: string;
+  carrier?: string;
+  tracking_number?: string;
+  version: number;
+}
+
+// Mock mode flag - set to false when API is ready
+const USE_MOCK = true;
+
+// API Base URL
+const API_BASE_URL = '/api/v1';
+
+// ==============================|| MOCK DATA ||============================== //
+
+const now = new Date();
+const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
+const threeDaysAgo = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000);
+
+let mockShippings: Shipping[] = [
+  {
+    id: 1,
+    order_id: 'ORD-2024-001',
+    status: 'CREATED',
+    carrier: null,
+    tracking_number: null,
+    shipping_address: '東京都渋谷区神南1-2-3 テストビル101',
+    ready_at: null,
+    shipped_at: null,
+    delivered_at: null,
+    version: 1,
+    created_at: twoDaysAgo.toISOString(),
+    updated_at: twoDaysAgo.toISOString()
+  },
+  {
+    id: 2,
+    order_id: 'ORD-2024-002',
+    status: 'READY',
+    carrier: null,
+    tracking_number: null,
+    shipping_address: '大阪府大阪市北区梅田1-1-1 グランフロント202',
+    ready_at: yesterday.toISOString(),
+    shipped_at: null,
+    delivered_at: null,
+    version: 2,
+    created_at: threeDaysAgo.toISOString(),
+    updated_at: yesterday.toISOString()
+  },
+  {
+    id: 3,
+    order_id: 'ORD-2024-003',
+    status: 'READY',
+    carrier: null,
+    tracking_number: null,
+    shipping_address: '愛知県名古屋市中区栄3-4-5 栄ビル303',
+    ready_at: now.toISOString(),
+    shipped_at: null,
+    delivered_at: null,
+    version: 1,
+    created_at: yesterday.toISOString(),
+    updated_at: now.toISOString()
+  },
+  {
+    id: 4,
+    order_id: 'ORD-2024-004',
+    status: 'SHIPPED',
+    carrier: 'YAMATO',
+    tracking_number: '1234-5678-9012',
+    shipping_address: '福岡県福岡市博多区博多駅前2-3-4',
+    ready_at: twoDaysAgo.toISOString(),
+    shipped_at: yesterday.toISOString(),
+    delivered_at: null,
+    version: 3,
+    created_at: threeDaysAgo.toISOString(),
+    updated_at: yesterday.toISOString()
+  },
+  {
+    id: 5,
+    order_id: 'ORD-2024-005',
+    status: 'SHIPPED',
+    carrier: 'SAGAWA',
+    tracking_number: '9876-5432-1098',
+    shipping_address: '北海道札幌市中央区大通西5-6-7',
+    ready_at: twoDaysAgo.toISOString(),
+    shipped_at: now.toISOString(),
+    delivered_at: null,
+    version: 3,
+    created_at: threeDaysAgo.toISOString(),
+    updated_at: now.toISOString()
+  },
+  {
+    id: 6,
+    order_id: 'ORD-2024-006',
+    status: 'DELIVERED',
+    carrier: 'JAPANPOST',
+    tracking_number: '5555-6666-7777',
+    shipping_address: '京都府京都市下京区四条通河原町東入',
+    ready_at: threeDaysAgo.toISOString(),
+    shipped_at: twoDaysAgo.toISOString(),
+    delivered_at: yesterday.toISOString(),
+    version: 4,
+    created_at: threeDaysAgo.toISOString(),
+    updated_at: yesterday.toISOString()
+  },
+  {
+    id: 7,
+    order_id: 'ORD-2024-007',
+    status: 'RETURNED',
+    carrier: 'YAMATO',
+    tracking_number: '1111-2222-3333',
+    shipping_address: '神奈川県横浜市西区みなとみらい1-2-3',
+    ready_at: threeDaysAgo.toISOString(),
+    shipped_at: twoDaysAgo.toISOString(),
+    delivered_at: null,
+    version: 4,
+    created_at: threeDaysAgo.toISOString(),
+    updated_at: yesterday.toISOString()
+  },
+  {
+    id: 8,
+    order_id: 'ORD-2024-008',
+    status: 'CREATED',
+    carrier: null,
+    tracking_number: null,
+    shipping_address: '兵庫県神戸市中央区三宮町1-2-3',
+    ready_at: null,
+    shipped_at: null,
+    delivered_at: null,
+    version: 1,
+    created_at: now.toISOString(),
+    updated_at: now.toISOString()
+  },
+  {
+    id: 9,
+    order_id: 'ORD-2024-009',
+    status: 'READY',
+    carrier: null,
+    tracking_number: null,
+    shipping_address: '広島県広島市中区紙屋町1-2-3',
+    ready_at: now.toISOString(),
+    shipped_at: null,
+    delivered_at: null,
+    version: 2,
+    created_at: yesterday.toISOString(),
+    updated_at: now.toISOString()
+  },
+  {
+    id: 10,
+    order_id: 'ORD-2024-010',
+    status: 'SHIPPED',
+    carrier: 'YAMATO',
+    tracking_number: '4444-5555-6666',
+    shipping_address: '宮城県仙台市青葉区一番町3-4-5',
+    ready_at: yesterday.toISOString(),
+    shipped_at: now.toISOString(),
+    delivered_at: null,
+    version: 3,
+    created_at: twoDaysAgo.toISOString(),
+    updated_at: now.toISOString()
+  }
+];
+
+function getMockSummary(): Summary {
+  return {
+    created: mockShippings.filter(s => s.status === 'CREATED').length,
+    ready: mockShippings.filter(s => s.status === 'READY').length,
+    shipped_today: mockShippings.filter(s => {
+      if (s.status !== 'SHIPPED' || !s.shipped_at) return false;
+      const shippedDate = new Date(s.shipped_at);
+      const today = new Date();
+      return shippedDate.toDateString() === today.toDateString();
+    }).length,
+    returned: mockShippings.filter(s => s.status === 'RETURNED').length
+  };
+}
+
+function getMockPriorityShippings(limit: number): Shipping[] {
+  const priority = mockShippings
+    .filter(s => ['CREATED', 'READY', 'RETURNED'].includes(s.status))
+    .sort((a, b) => {
+      // RETURNED first, then CREATED (older first), then READY
+      if (a.status === 'RETURNED' && b.status !== 'RETURNED') return -1;
+      if (a.status !== 'RETURNED' && b.status === 'RETURNED') return 1;
+      if (a.status === 'CREATED' && b.status !== 'CREATED') return -1;
+      if (a.status !== 'CREATED' && b.status === 'CREATED') return 1;
+      return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+    });
+  return priority.slice(0, limit);
+}
+
+function getMockShippings(params: ListParams): { data: Shipping[]; total: number } {
+  let filtered = [...mockShippings];
+
+  if (params.status) {
+    filtered = filtered.filter(s => s.status === params.status);
+  }
+  if (params.carrier) {
+    filtered = filtered.filter(s => s.carrier === params.carrier);
+  }
+  if (params.keyword) {
+    const keyword = params.keyword.toLowerCase();
+    filtered = filtered.filter(s =>
+      s.order_id.toLowerCase().includes(keyword) ||
+      (s.tracking_number && s.tracking_number.toLowerCase().includes(keyword))
+    );
+  }
+
+  const total = filtered.length;
+  const page = params.page || 1;
+  const size = params.size || 20;
+  const start = (page - 1) * size;
+  const end = start + size;
+
+  return {
+    data: filtered.slice(start, end),
+    total
+  };
+}
+
+function getMockShipping(orderId: string): Shipping | null {
+  return mockShippings.find(s => s.order_id === orderId) || null;
+}
+
+function updateMockShipping(orderId: string, data: UpdateParams): Shipping | null {
+  const index = mockShippings.findIndex(s => s.order_id === orderId);
+  if (index === -1) return null;
+
+  const shipping = mockShippings[index];
+
+  // Simulate optimistic locking
+  if (shipping.version !== data.version) {
+    throw new Error('CONFLICT');
+  }
+
+  const now = new Date().toISOString();
+  const updated: Shipping = {
+    ...shipping,
+    status: data.status,
+    carrier: data.carrier || shipping.carrier,
+    tracking_number: data.tracking_number || shipping.tracking_number,
+    version: shipping.version + 1,
+    updated_at: now
+  };
+
+  // Update timestamp fields based on status
+  if (data.status === 'READY' && !updated.ready_at) {
+    updated.ready_at = now;
+  }
+  if (data.status === 'SHIPPED' && !updated.shipped_at) {
+    updated.shipped_at = now;
+  }
+  if (data.status === 'DELIVERED' && !updated.delivered_at) {
+    updated.delivered_at = now;
+  }
+
+  mockShippings[index] = updated;
+  return updated;
+}
+
+// ==============================|| API FUNCTIONS ||============================== //
+
+/**
+ * Fetch with error handling
+ */
+async function fetchApi<T>(url: string, options: RequestInit = {}): Promise<ApiResponse<T>> {
+  try {
+    const response = await fetch(`${API_BASE_URL}${url}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...options.headers
+      },
+      ...options
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return {
+        success: false,
+        data: data.data,
+        errorCode: response.status,
+        errorMessage: data.message || data.error || 'Request failed'
+      };
+    }
+
+    return data;
+  } catch (error) {
+    return {
+      success: false,
+      data: null as unknown as T,
+      errorCode: 500,
+      errorMessage: error instanceof Error ? error.message : 'Network error'
+    };
+  }
+}
+
+/**
+ * 発送サマリ取得
+ * GET /api/v1/shipments/summary
+ */
+export async function getSummary(): Promise<ApiResponse<Summary>> {
+  if (USE_MOCK) {
+    await new Promise(resolve => setTimeout(resolve, 300));
+    return { success: true, data: getMockSummary() };
+  }
+  return fetchApi<Summary>('/shipments/summary');
+}
+
+/**
+ * 優先対応発送一覧取得
+ * GET /api/v1/shipments/priority
+ */
+export async function getPriorityShippings(limit = 5): Promise<ApiResponse<Shipping[]>> {
+  if (USE_MOCK) {
+    await new Promise(resolve => setTimeout(resolve, 300));
+    return { success: true, data: getMockPriorityShippings(limit) };
+  }
+  return fetchApi<Shipping[]>(`/shipments/priority?limit=${limit}`);
+}
+
+/**
+ * 発送一覧取得
+ * GET /api/v1/shipments
+ */
+export async function getShippings(params: ListParams = {}): Promise<ListResponse> {
+  if (USE_MOCK) {
+    await new Promise(resolve => setTimeout(resolve, 300));
+    const result = getMockShippings(params);
+    return {
+      success: true,
+      data: result.data,
+      total: result.total,
+      page: params.page || 1,
+      size: params.size || 20
+    };
+  }
+
+  const searchParams = new URLSearchParams();
+
+  if (params.status) searchParams.append('status', params.status);
+  if (params.carrier) searchParams.append('carrier', params.carrier);
+  if (params.keyword) searchParams.append('keyword', params.keyword);
+  if (params.page) searchParams.append('page', String(params.page));
+  if (params.size) searchParams.append('size', String(params.size));
+
+  const queryString = searchParams.toString();
+  const response = await fetch(`${API_BASE_URL}/shipments${queryString ? `?${queryString}` : ''}`, {
+    headers: { 'Content-Type': 'application/json' }
+  });
+  return response.json();
+}
+
+/**
+ * 発送詳細取得
+ * GET /api/v1/shipments/:orderId
+ */
+export async function getShipping(orderId: string): Promise<ApiResponse<Shipping>> {
+  if (USE_MOCK) {
+    await new Promise(resolve => setTimeout(resolve, 200));
+    const shipping = getMockShipping(orderId);
+    if (shipping) {
+      return { success: true, data: shipping };
+    }
+    return { success: false, data: null as unknown as Shipping, errorCode: 404, errorMessage: 'Not found' };
+  }
+  return fetchApi<Shipping>(`/shipments/${orderId}`);
+}
+
+/**
+ * 発送更新
+ * PUT /api/v1/shipments/:orderId
+ */
+export async function updateShipping(orderId: string, data: UpdateParams): Promise<ApiResponse<Shipping>> {
+  if (USE_MOCK) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+    try {
+      const shipping = updateMockShipping(orderId, data);
+      if (shipping) {
+        return { success: true, data: shipping };
+      }
+      return { success: false, data: null as unknown as Shipping, errorCode: 404, errorMessage: 'Not found' };
+    } catch (error) {
+      if (error instanceof Error && error.message === 'CONFLICT') {
+        return { success: false, data: null as unknown as Shipping, errorCode: 409, errorMessage: 'Conflict' };
+      }
+      throw error;
+    }
+  }
+  return fetchApi<Shipping>(`/shipments/${orderId}`, {
+    method: 'PUT',
+    body: JSON.stringify(data)
+  });
+}
+
+// Constants
+export const STATUS_COLORS: Record<string, 'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning'> = {
+  CREATED: 'default',
+  READY: 'primary',
+  SHIPPED: 'success',
+  DELIVERED: 'info',
+  RETURNED: 'error',
+  CANCELLED: 'warning'
+};
+
+export const STATUS_LABELS: Record<string, string> = {
+  CREATED: '未着手',
+  READY: '出荷準備中',
+  SHIPPED: '出荷済み',
+  DELIVERED: '配達完了',
+  RETURNED: '返送',
+  CANCELLED: 'キャンセル'
+};
+
+export const CARRIER_NAMES: Record<string, string> = {
+  YAMATO: 'ヤマト運輸',
+  SAGAWA: '佐川急便',
+  JAPANPOST: '日本郵便'
+};
+
+export const CARRIER_TRACKING_URLS: Record<string, string> = {
+  YAMATO: 'https://jizen.kuronekoyamato.co.jp/jizen/servlet/crjz.b.NQ0010?id=',
+  SAGAWA: 'https://k2k.sagawa-exp.co.jp/p/web/okurijosearch.do?okurijoNo=',
+  JAPANPOST: 'https://trackings.post.japanpost.jp/services/srv/search/?requestNo1='
+};


### PR DESCRIPTION
## 概要
Material UIベースの管理画面に発送管理機能を実装し、APIと接続

## 実装内容

### Issue-401: 発送管理メニュー追加
- サイドメニューに「発送管理」グループを追加
- 子メニュー: 発送管理サマリー、発送一覧

### Issue-402: 発送管理サマリー画面
- 件数サマリーカード（未着手/出荷作業待ち/本日出荷/返送）
- 要対応発送リスト
- カードクリックで一覧画面へフィルタ遷移

### Issue-403: 発送一覧・詳細画面
- フィルタ機能（ステータス/配送業者/キーワード）
- ページネーション対応テーブル
- 詳細ドロワー（ステータス更新、返送処理）
- 楽観ロック（409 Conflict）対応
- 追跡番号コピー/追跡サイトリンク

### Issue-404: 一括操作・ソート機能
- チェックボックスによる複数選択
- 一括ステータス変更
- CSVエクスポート
- テーブルソート機能

### Issue-405: ステータス操作制御
- ステータスに応じた操作可否制御
- READY→SHIPPED時のバリデーション
- 返送処理（確認ダイアログ）

### API連携
- モックモード無効化、実API接続
- Viteプロキシ設定（/api/v1 → localhost:8080）
- .env.example追加

### ドキュメント更新
- `docs/design/ui-api-interface-mapping.md` v0.4.0へ更新
- 全APIエンドポイントとレスポンス形式を記載

## 変更ファイル
- `apps/admin-mui/src/menu-items/shipping.tsx` - メニュー定義
- `apps/admin-mui/src/menu-items/index.jsx` - メニュー登録
- `apps/admin-mui/src/routes/MainRoutes.jsx` - ルーティング
- `apps/admin-mui/src/pages/shipping/summary.tsx` - サマリー画面
- `apps/admin-mui/src/pages/shipping/list.tsx` - 一覧画面
- `apps/admin-mui/src/pages/shipping/components/ShippingDetailDrawer.tsx` - 詳細ドロワー
- `apps/admin-mui/src/services/shipping.ts` - APIサービス
- `apps/admin-mui/vite.config.mjs` - APIプロキシ設定
- `apps/admin-mui/.env.example` - 環境変数サンプル
- `docs/design/ui-api-interface-mapping.md` - API仕様書

## 動作確認

### APIサーバー起動
```bash
cd apps/api && go run cmd/server/main.go
```

### MUI Admin起動
```bash
cd apps/admin-mui && yarn start
```

### 画面URL
- http://localhost:3004/free/shipping/summary
- http://localhost:3004/free/shipping/list

## 備考
- モックモードで開発する場合は `src/services/shipping.ts` の `USE_MOCK = true` に変更

Closes #41, Closes #42, Closes #43, Closes #45, Closes #46